### PR TITLE
fix: 🐛 logo is not displayed in the installed plugin

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -20,7 +20,7 @@ module.exports = {
       "@semantic-release/exec",
       {
         prepareCmd:
-          "zip -qq -r logseq-plugin-bullet-threading-${nextRelease.version}.zip dist readme.md LICENSE package.json",
+          "zip -qq -r logseq-plugin-bullet-threading-${nextRelease.version}.zip dist readme.md LICENSE package.json logo.png",
       },
     ],
     [


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17695989/149865366-0c7f95aa-ac74-4cda-9785-7a34d51a7bff.png)
